### PR TITLE
Add Copilot commands for inline chat and chat sidebar

### DIFF
--- a/copilot/README.md
+++ b/copilot/README.md
@@ -1,0 +1,30 @@
+# VSCode Copilot
+
+This directory contains some very experimental commands for interacting with Copilot.
+
+## Inline chat / refactoring / code generation
+
+There are some commands to interact with the inline chat, leveraging Cursorless targets:
+
+| Command                               | Description                                                                                                  | Example                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `"pilot change <target>"`             | selects target and opens inline chat to enable typing instructions for how Copilot should change the target. | `"pilot change funk air"`                                     |
+| `"pilot change <target> to <phrase>"` | tells Copilot to apply the instructions in `<phrase>` to the target.                                         | `"pilot change funk air to remove arguments"`.                |
+| `"pilot test <target>"`               | Asks copilot to generate a test for the target.                                                              | `"pilot test funk air"`                                       |
+| `"pilot doc <target>"`                | Asks copilot to generate documentation for the target.                                                       | `"pilot doc funk air"`                                        |
+| `"pilot fix <target>"`                | Tells copilot to fix the target.                                                                             | `"pilot fix funk air"`                                        |
+| `"pilot fix <target> to <phrase>"`    | Tells copilot to fix the target using the instructions in `<phrase>`.                                        | `"pilot fix funk air to remove warnings"`                     |
+| `"pilot make <phrase>"`               | Tells copilot to generate code using the instructions in `<phrase>`, at the current cursor position.         | `"pilot make a function that returns the sum of two numbers"` |
+
+## Chat sidebar
+
+There are some commands to interact with the chat sidebar:
+
+| Command                                 | Description                                                                                    | Example                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `"pilot chat"`                          | opens chat to enable typing                                                                    |                                                                          |
+| `"pilot chat hello world"`              | opens chat, types "hello world" and hits enter                                                 |                                                                          |
+| `"pilot bring <ordinal>"`               | inserts nth code block in most recent chat response into your editor at cursor position        | `"pilot bring first"`, `"pilot bring last"`, `"pilot bring second last"` |
+| `"pilot copy <ordinal>"`                | copies nth code block in most recent chat response                                             | `"pilot copy first"`                                                     |
+| `"pilot bring <ordinal> <destination>"` | inserts nth code block in most recent chat response into your editor at Cursorless destination | `"pilot bring first after state air"`, `"pilot bring first to line air"` |
+| `"pilot bring first to funk"`           | replaces function containing your cursor with first code block in most recent chat response    |                                                                          |

--- a/copilot/copilot.py
+++ b/copilot/copilot.py
@@ -1,0 +1,72 @@
+from talon import Context, Module, actions
+
+mod = Module()
+ctx = Context()
+
+ctx.matches = r"""
+app: vscode
+"""
+
+mod.list(
+    "copilot_slash_command", "Slash commands that can be used with copilot, e.g. /test"
+)
+ctx.lists["user.copilot_slash_command"] = {
+    "test": "tests",
+    "dock": "doc",
+    "fix": "fix",
+    "explain": "explain",
+    "change": "",
+}
+
+mod.list("makeshift_destination", "Cursorless makeshift destination")
+ctx.lists["user.makeshift_destination"] = {
+    "to": "clearAndSetSelection",
+    "after": "editNewLineAfter",
+    "before": "editNewLineBefore",
+}
+
+
+@mod.action_class
+class Actions:
+    def copilot_inline_chat(copilot_slash_command: str = "", prose: str = ""):
+        """Initiate copilot inline chat session"""
+        actions.user.run_rpc_command(
+            "editor.action.codeAction",
+            {
+                "kind": "refactor.rewrite",
+            },
+        )
+        has_content = copilot_slash_command or prose
+        if has_content:
+            actions.sleep("50ms")
+        if copilot_slash_command:
+            actions.insert(f"/{copilot_slash_command} ")
+        if prose:
+            actions.insert(prose)
+        if has_content:
+            actions.key("enter")
+
+    def copilot_chat(prose: str):
+        """Initiate copilot chat session"""
+        actions.user.vscode("workbench.panel.chat.view.copilot.focus")
+        if prose:
+            actions.sleep("50ms")
+            actions.insert(prose)
+            actions.key("enter")
+
+    def copilot_focus_code_block(index: int):
+        """Bring a copilot chat suggestion to the cursor"""
+        actions.user.vscode("workbench.panel.chat.view.copilot.focus")
+        action = (
+            "workbench.action.chat.previousCodeBlock"
+            if index < 0
+            else "workbench.action.chat.nextCodeBlock"
+        )
+        count = index + 1 if index >= 0 else abs(index)
+        for _ in range(count):
+            actions.user.vscode(action)
+
+    def copilot_bring_code_block(index: int):
+        """Bring a copilot chat suggestion to the cursor"""
+        actions.user.copilot_focus_code_block(index)
+        actions.user.vscode("workbench.action.chat.insertCodeBlock")

--- a/copilot/copilot.talon
+++ b/copilot/copilot.talon
@@ -1,0 +1,28 @@
+app: vscode
+-
+pilot jest: user.vscode("editor.action.inlineSuggest.trigger")
+pilot next: user.vscode("editor.action.inlineSuggest.showNext")
+pilot last: user.vscode("editor.action.inlineSuggest.showPrevious")
+pilot yes: user.vscode("editor.action.inlineSuggest.commit")
+pilot yes word: user.vscode("editor.action.inlineSuggest.acceptNextWord")
+pilot nope: user.vscode("editor.action.inlineSuggest.undo")
+pilot cancel: user.vscode("editor.action.inlineSuggest.hide")
+pilot block last: user.vscode("workbench.action.chat.previousCodeBlock")
+pilot block next: user.vscode("workbench.action.chat.nextCodeBlock")
+pilot new file <user.ordinal_or_last>:
+    user.copilot_focus_code_block(ordinal_or_last)
+    user.vscode("workbench.action.chat.insertIntoNewFile")
+pilot copy <user.ordinal_or_last>:
+    user.copilot_focus_code_block(ordinal_or_last)
+    edit.copy()
+pilot bring <user.ordinal_or_last>: user.copilot_bring_code_block(ordinal_or_last)
+pilot bring <user.ordinal_or_last> {user.makeshift_destination} <user.cursorless_target>:
+    user.cursorless_command(makeshift_destination, cursorless_target)
+    user.copilot_bring_code_block(ordinal_or_last)
+pilot chat [<user.prose>]$:
+    user.copilot_chat(prose or "")
+pilot {user.copilot_slash_command} <user.cursorless_target> [to <user.prose>]$:
+    user.cursorless_command("setSelection", cursorless_target)
+    user.copilot_inline_chat(copilot_slash_command or "", prose or "")
+pilot make [<user.prose>]:
+    user.copilot_inline_chat("", prose or "")


### PR DESCRIPTION
Contains some very experimental commands for interacting with Copilot, several of which integrate with Cursorless targets. See included README for more info